### PR TITLE
fix：ci， gate keystore step via env; map secrets at job level (fix Actions…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
     name: Build Android
     needs: derive-version
     runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_ALIAS_PASSWORD: ${{ secrets.ANDROID_KEY_ALIAS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -66,12 +71,7 @@ jobs:
         run: flutter test --no-pub
 
       - name: Configure Android keystore (optional)
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_ALIAS_PASSWORD: ${{ secrets.ANDROID_KEY_ALIAS_PASSWORD }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
         shell: bash
         run: |
           mkdir -p android


### PR DESCRIPTION
## 背景
- 打标签触发发布时出现校验错误：
  - Invalid workflow file: Unrecognized named-value: 'secrets'（在 step 的 `if:` 表达式中）
- 原因：GitHub 不允许在 step 级 `if:` 直接引用 `secrets.*` 做条件判断。

## 变更
- 在 `build-android` job 级映射 Secrets 到环境变量：
  - `ANDROID_KEYSTORE_BASE64`
  - `ANDROID_KEYSTORE_PASSWORD`
  - `ANDROID_KEY_ALIAS`
  - `ANDROID_KEY_ALIAS_PASSWORD`
- 将 keystore 步骤的条件判断改为使用 env：
  - `if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}`
- 未改动构建逻辑与产物，仅修复工作流校验问题。

## 影响
- 行为保持不变：配置了 Secrets 则执行签名注入；未配置则跳过。
- 工作流可被 GitHub 正常解析，不再出现 “Invalid workflow file”。

## 验证
- 合并后打一个测试标签观察 Actions：
  ```bash
  git tag v0.0.1-rc2
  git push origin v0.0.1-rc2
