### PR TITLE
flutter: enable generate: true to allow gen_l10n during CI

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  generate: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## 背景
- CI 报错：
  - Attempted to generate localizations code without having the `flutter: generate` flag turned on.
- 原因：
  - `pubspec.yaml` 缺少 `flutter: generate: true`，导致 gen_l10n 无法运行。

## 变更
- 在 `pubspec.yaml` 的 `flutter:` 节下新增：
  - `generate: true`

## 影响
- 仅调整构建配置，不影响业务逻辑与运行时行为。
- CI 可正常生成本地化代码并继续打包。

## 验证
1) 合并此 PR 后打测试标签触发发布：
   ```bash
   git checkout main && git pull
   git tag v0.0.1-rc6
   git push origin v0.0.1-rc6
