### PR TITLE
Fix Flutter Android build compatibility

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true

--- a/lib/features/timer/presentation/widgets/settings/timer_settings_sections.dart
+++ b/lib/features/timer/presentation/widgets/settings/timer_settings_sections.dart
@@ -37,7 +37,7 @@ class LanguageSelectorSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DropdownButtonFormField<AppLanguage>(
-      initialValue: controller.language,
+      value: controller.language,
       decoration: InputDecoration(labelText: l10n.settingsLanguageLabel),
       items: AppLanguage.values
           .map(
@@ -80,7 +80,7 @@ class SpeechModeSelectorSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DropdownButtonFormField<SpeechMode>(
-      initialValue: controller.speechMode,
+      value: controller.speechMode,
       decoration: InputDecoration(
         labelText: l10n.settingsSpeechModeLabel,
         helperText: l10n.settingsSpeechModeHelp,


### PR DESCRIPTION
## What changed
- use Flutter 3.29-compatible DropdownButtonFormField values
- reduce Gradle JVM memory limits for stable local emulator builds

## Why
The current Flutter SDK does not support the previous dropdown parameter, and the prior 8 GB Gradle heap competed with the Android emulator for memory.

## Validation
- flutter test
- android/gradlew.bat assembleDebug --no-daemon --console=plain