### PR TITLE
Validate Android signing files in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,20 @@ jobs:
             -storepass "$ANDROID_KEYSTORE_PASSWORD" -alias "$ANDROID_KEY_ALIAS" \
             | grep -E "SHA1|SHA-1" || true
 
+      - name: Validate signing files exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -l android || true
+          if [[ ! -s android/release.keystore ]]; then
+            echo "release.keystore is missing or empty. Check ANDROID_KEYSTORE_BASE64 secret (must be base64 of the .keystore/.jks binary)." >&2
+            exit 1
+          fi
+          if [[ ! -s android/key.properties ]]; then
+            echo "key.properties is missing or empty after generation." >&2
+            exit 1
+          fi
+
       - name: Build Android APK (universal)
         run: |
           flutter build apk \


### PR DESCRIPTION
## What changed
- fail the release workflow early when the generated keystore or key.properties is missing

## Why
This makes signing-secret failures explicit before the APK build starts.