### PR TITLE
build: prepare Google Play release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,13 @@ jobs:
             --build-name "${{ needs.derive-version.outputs.build_name }}" \
             --build-number "${{ needs.derive-version.outputs.build_number }}"
 
+      - name: Build Android App Bundle (AAB)
+        run: |
+          flutter build appbundle \
+            --release \
+            --build-name "${{ needs.derive-version.outputs.build_name }}" \
+            --build-number "${{ needs.derive-version.outputs.build_number }}"
+
       - name: Print APK signature (SHA1)
         run: |
           echo "Universal APK fingerprint (SHA1):"
@@ -175,6 +182,7 @@ jobs:
             build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
             build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
             build/app/outputs/flutter-apk/app-x86_64-release.apk
+            build/app/outputs/bundle/release/app-release.aab
 
   release:
     if: needs.guard.outputs.allowed == 'true'

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    namespace = "io.github.wumoye.courttimer"
+    namespace = "com.wumoye.courttimer"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "io.github.wumoye.courttimer"
+        applicationId = "com.wumoye.courttimer"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/com/wumoye/courttimer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wumoye/courttimer/MainActivity.kt
@@ -1,4 +1,4 @@
-package io.github.wumoye.courttimer
+package com.wumoye.courttimer
 
 import android.content.Context
 import android.os.Build
@@ -13,7 +13,7 @@ class MainActivity : FlutterActivity() {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
-            "io.github.wumoye.courttimer/vibration",
+            "com.wumoye.courttimer/vibration",
         ).setMethodCallHandler { call, result ->
             if (call.method != "pauseResume") {
                 result.notImplemented()

--- a/lib/core/platform/pause_resume_vibration.dart
+++ b/lib/core/platform/pause_resume_vibration.dart
@@ -5,7 +5,7 @@ class PauseResumeVibration {
   PauseResumeVibration._();
 
   static const MethodChannel _channel = MethodChannel(
-    'io.github.wumoye.courttimer/vibration',
+    'com.wumoye.courttimer/vibration',
   );
 
   static Future<void> vibrate() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+1
+version: 1.1.10+10
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
## Summary
- migrate Android application ID to com.wumoye.courttimer for Google Play
- retain native pause/resume vibration under the migrated Activity
- build and upload a release AAB alongside APKs
- align source version to 1.1.10+10

## Validation
- flutter test (6 passed)
- Android debug build succeeded