### PR TITLE
Stabilize timer speech and audio focus

### DIFF
--- a/android/app/src/main/kotlin/com/wumoye/courttimer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wumoye/courttimer/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.wumoye.courttimer
 
 import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
@@ -9,6 +12,8 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
+    private var duckingFocusRequest: AudioFocusRequest? = null
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(
@@ -35,6 +40,49 @@ class MainActivity : FlutterActivity() {
                 vibrator.vibrate(60)
             }
             result.success(true)
+        }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.wumoye.courttimer/audio_focus",
+        ).setMethodCallHandler { call, result ->
+            val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+            when (call.method) {
+                "requestDucking" -> {
+                    val attributes = AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build()
+                    val requestResult = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        duckingFocusRequest = AudioFocusRequest.Builder(
+                            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+                        )
+                            .setAudioAttributes(attributes)
+                            .setOnAudioFocusChangeListener { }
+                            .build()
+                        audioManager.requestAudioFocus(duckingFocusRequest!!)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        audioManager.requestAudioFocus(
+                            null,
+                            AudioManager.STREAM_MUSIC,
+                            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+                        )
+                    }
+                    result.success(requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+                }
+                "abandonDucking" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        duckingFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+                        duckingFocusRequest = null
+                    } else {
+                        @Suppress("DEPRECATION")
+                        audioManager.abandonAudioFocus(null)
+                    }
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
         }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true

--- a/lib/features/timer/controller/timer_controller.dart
+++ b/lib/features/timer/controller/timer_controller.dart
@@ -43,9 +43,9 @@ class TimerController extends ChangeNotifier {
   bool _disposed = false;
   bool _hasStartedOnce = false;
   bool _startPending = false;
-  bool _finalCountdownSpeechActive = false;
   int _speechGeneration = 0;
   Future<void> _pendingSpeechStop = Future<void>.value();
+  Future<void> _finalCountdownSpeechQueue = Future<void>.value();
 
   Future<void> init() async {
     await _speech.init();
@@ -69,7 +69,7 @@ class TimerController extends ChangeNotifier {
     _ticker?.cancel();
     unawaited(_disableWake());
     _speechGeneration++;
-    _finalCountdownSpeechActive = false;
+    _finalCountdownSpeechQueue = Future<void>.value();
     _pendingSpeechStop = _speech.stop();
     _setState(
       _state.copyWith(
@@ -85,7 +85,7 @@ class TimerController extends ChangeNotifier {
     _ticker?.cancel();
     unawaited(_disableWake());
     _speechGeneration++;
-    _finalCountdownSpeechActive = false;
+    _finalCountdownSpeechQueue = Future<void>.value();
     _pendingSpeechStop = _speech.stop();
     final target = seconds ?? _state.selectedSeconds;
     final options = _rebuildDurationOptions(target);
@@ -161,6 +161,8 @@ class TimerController extends ChangeNotifier {
   void dispose() {
     _ticker?.cancel();
     unawaited(_disableWake());
+    _speechGeneration++;
+    _finalCountdownSpeechQueue = Future<void>.value();
     _speech.dispose();
     _disposed = true;
     super.dispose();
@@ -197,6 +199,13 @@ class TimerController extends ChangeNotifier {
           prestartCount: null,
         ),
       );
+      // Pausing stops TTS and clears its queue. Replay the second currently
+      // shown on screen before ticking again so resuming at (for example) 7
+      // never jumps straight to a spoken 6.
+      final remaining = _state.remainingSeconds;
+      if (_state.enableFinalCountdown && remaining > 0 && remaining <= 10) {
+        _announceFinalNumber(remaining);
+      }
       _startTicker();
       return;
     }
@@ -277,7 +286,6 @@ class TimerController extends ChangeNotifier {
       }
 
       if (next <= 0) {
-        unawaited(_speech.speakTimeUp());
         timer.cancel();
         unawaited(_disableWake());
         _setState(
@@ -290,6 +298,7 @@ class TimerController extends ChangeNotifier {
           ),
         );
         _hasStartedOnce = false;
+        _enqueueFinalTimeUp();
         return;
       }
 
@@ -298,21 +307,33 @@ class TimerController extends ChangeNotifier {
   }
 
   void _announceFinalNumber(int number) {
-    // Android TTS is a single output stream. Do not enqueue stale countdown
-    // numbers while the current one is still playing, otherwise they overlap.
-    if (_finalCountdownSpeechActive) {
-      return;
-    }
-
-    _finalCountdownSpeechActive = true;
     final generation = _speechGeneration;
-    unawaited(
-      _speech.speakNumber(number).whenComplete(() {
-        if (generation == _speechGeneration) {
-          _finalCountdownSpeechActive = false;
-        }
-      }),
-    );
+    // Keep all 10 final numbers in order. The old "busy" gate intentionally
+    // dropped a number whenever device TTS took longer than one second.
+    _finalCountdownSpeechQueue = _finalCountdownSpeechQueue.then((_) async {
+      if (generation != _speechGeneration) {
+        return;
+      }
+      try {
+        await _speech.speakNumber(number);
+      } catch (_) {
+        // Speech feedback must never stall the timer or the next queued item.
+      }
+    });
+  }
+
+  void _enqueueFinalTimeUp() {
+    final generation = _speechGeneration;
+    _finalCountdownSpeechQueue = _finalCountdownSpeechQueue.then((_) async {
+      if (generation != _speechGeneration) {
+        return;
+      }
+      try {
+        await _speech.speakTimeUp();
+      } catch (_) {
+        // The visual timer has already completed even if platform TTS fails.
+      }
+    });
   }
 
   bool _shouldAnnounceMilestone(int seconds) {

--- a/lib/features/timer/presentation/widgets/settings/timer_settings_controller.dart
+++ b/lib/features/timer/presentation/widgets/settings/timer_settings_controller.dart
@@ -17,6 +17,7 @@ class TimerSettingsController extends ChangeNotifier {
   StreamSubscription<PlayerState>? _previewStateSub;
   Timer? _previewFallbackTimer;
   bool _isPreviewing = false;
+  bool _previewAudioContextConfigured = false;
 
   Future<bool> playPreview(String? asset) async {
     if (asset == null || asset.isEmpty) {
@@ -31,6 +32,7 @@ class TimerSettingsController extends ChangeNotifier {
           ..setPlayerMode(PlayerMode.lowLatency);
 
     try {
+      await _configurePreviewAudioContext();
       await _previewPlayer!.stop();
       await _previewCompleteSub?.cancel();
       await _previewStateSub?.cancel();
@@ -87,5 +89,17 @@ class TimerSettingsController extends ChangeNotifier {
     _previewStateSub = null;
     _previewFallbackTimer?.cancel();
     _previewFallbackTimer = null;
+  }
+
+  /// A settings preview is not a timer prompt. It should layer over existing
+  /// media instead of asking Android to pause or duck another app.
+  Future<void> _configurePreviewAudioContext() async {
+    if (_previewAudioContextConfigured) {
+      return;
+    }
+    await _previewPlayer!.setAudioContext(
+      AudioContextConfig(focus: AudioContextConfigFocus.mixWithOthers).build(),
+    );
+    _previewAudioContextConfigured = true;
   }
 }

--- a/lib/features/timer/services/speech_service.dart
+++ b/lib/features/timer/services/speech_service.dart
@@ -33,6 +33,7 @@ class SpeechService implements TimerSpeechService {
   final AudioPlayer _audioPlayer = AudioPlayer();
   final AudioPlayer _feedbackPlayer = AudioPlayer();
   bool _initialized = false;
+  bool _audioContextConfigured = false;
 
   AppLanguage get _language => _settings.language;
   SpeechMode get _mode => _settings.speechMode;
@@ -43,7 +44,9 @@ class SpeechService implements TimerSpeechService {
     }
   }
 
+  @override
   Future<void> init() async {
+    await _configurePlaybackAudioContext();
     if (_mode != SpeechMode.systemTts) {
       // TODO: 支持其他语音模式（离线音频 / 在线服务）
       return;
@@ -52,23 +55,35 @@ class SpeechService implements TimerSpeechService {
       return;
     }
     await _tts.awaitSpeakCompletion(true);
+    // On Android this marks speech as a navigation-style prompt, rather than
+    // media playback. Together with `focus: true` in _speak this requests a
+    // short-lived focus that lets the music app duck and resume automatically.
+    try {
+      await _tts.setAudioAttributesForNavigation();
+    } catch (_) {
+      // This Android-specific hint is optional on the other platforms.
+    }
     _initialized = true;
     await _applyTtsConfiguration();
   }
 
+  @override
   Future<void> speakStart() async {
     await _speak(_startPrompt());
   }
 
+  @override
   Future<void> speakTimeUp() async {
     await _speak(_timeUpPrompt());
     await _playEndSound();
   }
 
+  @override
   Future<void> speakNumber(int number) async {
     await _speak(speechNumberFor(_language, number));
   }
 
+  @override
   Future<void> speakRemaining(int seconds) async {
     final remainingLabel = speechLabelFor(_language, seconds);
     if (remainingLabel.isEmpty) {
@@ -77,6 +92,7 @@ class SpeechService implements TimerSpeechService {
     await _speak('${_remainingPrefix()}$remainingLabel${_sentenceEnding()}');
   }
 
+  @override
   Future<void> stop() async {
     if (_mode == SpeechMode.systemTts) {
       await _tts.stop();
@@ -102,6 +118,7 @@ class SpeechService implements TimerSpeechService {
     }
   }
 
+  @override
   void dispose() {
     _settings.removeListener(_handleSettingsChanged);
     _tts.stop();
@@ -116,7 +133,7 @@ class SpeechService implements TimerSpeechService {
     await _tts.setLanguage(_language.ttsLocaleTag);
     await _tts.setSpeechRate(_settings.speechRate);
     await _tts.setPitch(_pitchFor(_language));
-    await _tts.setVolume(0.9);
+    await _tts.setVolume(1.0);
   }
 
   // 保留音高按语言微调；语速改由 Settings 控制
@@ -182,7 +199,7 @@ class SpeechService implements TimerSpeechService {
         return;
       }
       await _tts.stop();
-      await _tts.speak(text);
+      await _tts.speak(text, focus: true);
     } catch (_) {
       // TTS is optional feedback. A platform-engine failure must not block
       // timer state changes or surface as an unhandled asynchronous error.
@@ -210,6 +227,25 @@ class SpeechService implements TimerSpeechService {
       }
     } catch (_) {
       await SystemSound.play(SystemSoundType.alert);
+    }
+  }
+
+  /// Makes timer prompts transient audio instead of competing media playback.
+  /// Android then uses `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`; iOS uses its
+  /// equivalent duck-and-mix session configuration.
+  Future<void> _configurePlaybackAudioContext() async {
+    if (_audioContextConfigured) {
+      return;
+    }
+
+    final duckingContext =
+        AudioContextConfig(focus: AudioContextConfigFocus.duckOthers).build();
+    try {
+      await _audioPlayer.setAudioContext(duckingContext);
+      await _feedbackPlayer.setAudioContext(duckingContext);
+      _audioContextConfigured = true;
+    } catch (_) {
+      // Audio feedback remains best-effort if a platform lacks audio contexts.
     }
   }
 }

--- a/lib/features/timer/services/speech_service.dart
+++ b/lib/features/timer/services/speech_service.dart
@@ -201,8 +201,10 @@ class SpeechService implements TimerSpeechService {
       if (_mode != SpeechMode.systemTts) {
         return;
       }
+      // Stop can cause an Android TTS engine to abandon audio focus. It must
+      // happen before requesting the focus that ducks background music.
+      await _tts.stop();
       await _withDuckedBackgroundAudio(() async {
-        await _tts.stop();
         // The Android method channel owns the transient ducking focus. Letting
         // the TTS engine request its own focus here can override that request
         // on some devices and prevent the background player from ducking.

--- a/lib/features/timer/services/speech_service.dart
+++ b/lib/features/timer/services/speech_service.dart
@@ -32,6 +32,9 @@ class SpeechService implements TimerSpeechService {
   final FlutterTts _tts = FlutterTts();
   final AudioPlayer _audioPlayer = AudioPlayer();
   final AudioPlayer _feedbackPlayer = AudioPlayer();
+  static const _audioFocusChannel = MethodChannel(
+    'com.wumoye.courttimer/audio_focus',
+  );
   bool _initialized = false;
   bool _audioContextConfigured = false;
 
@@ -198,8 +201,13 @@ class SpeechService implements TimerSpeechService {
       if (_mode != SpeechMode.systemTts) {
         return;
       }
-      await _tts.stop();
-      await _tts.speak(text, focus: true);
+      await _withDuckedBackgroundAudio(() async {
+        await _tts.stop();
+        // The Android method channel owns the transient ducking focus. Letting
+        // the TTS engine request its own focus here can override that request
+        // on some devices and prevent the background player from ducking.
+        await _tts.speak(text);
+      });
     } catch (_) {
       // TTS is optional feedback. A platform-engine failure must not block
       // timer state changes or surface as an unhandled asynchronous error.
@@ -246,6 +254,27 @@ class SpeechService implements TimerSpeechService {
       _audioContextConfigured = true;
     } catch (_) {
       // Audio feedback remains best-effort if a platform lacks audio contexts.
+    }
+  }
+
+  Future<void> _withDuckedBackgroundAudio(
+    Future<void> Function() action,
+  ) async {
+    var focusGranted = false;
+    try {
+      focusGranted =
+          await _audioFocusChannel.invokeMethod<bool>('requestDucking') ??
+          false;
+      await action();
+    } finally {
+      if (focusGranted) {
+        try {
+          await _audioFocusChannel.invokeMethod<void>('abandonDucking');
+        } catch (_) {
+          // Audio focus is an Android enhancement; keep speech functional if
+          // the platform channel is unavailable.
+        }
+      }
     }
   }
 }

--- a/test/timer_controller_test.dart
+++ b/test/timer_controller_test.dart
@@ -11,6 +11,7 @@ class _FakeSpeech implements TimerSpeechService {
   int timeUpCalls = 0;
   int stopCalls = 0;
   Completer<void>? _blockedNumber;
+  Completer<void>? _activeBlockedNumber;
   int? _numberToBlock;
   Completer<void>? _pendingStop;
 
@@ -26,6 +27,11 @@ class _FakeSpeech implements TimerSpeechService {
     _pendingStop = null;
   }
 
+  void completeBlockedNumber() {
+    _activeBlockedNumber?.complete();
+    _activeBlockedNumber = null;
+  }
+
   @override
   void dispose() {}
 
@@ -37,6 +43,7 @@ class _FakeSpeech implements TimerSpeechService {
     numbers.add(number);
     final blocked = number == _numberToBlock ? _blockedNumber : null;
     if (blocked != null) {
+      _activeBlockedNumber = blocked;
       _blockedNumber = null;
       _numberToBlock = null;
     }
@@ -116,8 +123,37 @@ void main() {
       await controller.toggleStartPause();
       await Future<void>.delayed(const Duration(milliseconds: 80));
 
+      expect(speech.numbers, contains(pausedAt));
       expect(speech.numbers, contains(pausedAt - 1));
       expect(controller.state.isRunning, isTrue);
+    },
+  );
+
+  test(
+    'queues every final countdown number before the time-up prompt',
+    () async {
+      final speech = _FakeSpeech();
+      final controller = await createController(speech);
+      addTearDown(controller.dispose);
+
+      speech.blockNumber(10);
+      await controller.toggleStartPause();
+      final prestartAnnouncements = speech.numbers.length;
+      await Future<void>.delayed(const Duration(milliseconds: 280));
+
+      expect(controller.state.remainingSeconds, 0);
+      final countdownNumbers = speech.numbers.skip(prestartAnnouncements);
+      expect(countdownNumbers, contains(10));
+      expect(countdownNumbers.where((number) => number < 10), isEmpty);
+
+      speech.completeBlockedNumber();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        speech.numbers.skip(prestartAnnouncements),
+        containsAllInOrder(<int>[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+      );
+      expect(speech.timeUpCalls, 1);
     },
   );
 


### PR DESCRIPTION
## What changed

- request transient audio focus for timer prompts
- keep settings previews mixed with background audio
- serialize the final 10-second countdown so digits are not skipped
- replay the current final-countdown second after pause/resume
- increase Gradle heap for reliable signed CI builds

## Why

Timer speech could skip or cut off final-countdown numbers, settings previews interrupted other media, and signed CI builds ran out of Gradle heap.

## Validation

- flutter analyze
- timer controller tests
- signed Android release build
- feature branch CI passed